### PR TITLE
Refactor: Centralize track state in background script

### DIFF
--- a/src/content/youtube-music.ts
+++ b/src/content/youtube-music.ts
@@ -670,63 +670,12 @@ export class YouTubeMusicDetector {
         // Settings were updated, we might need to re-evaluate current track
         this.detectCurrentTrack();
         break;
-      case MESSAGE_TYPES.GET_CURRENT_TRACK:
-        // Send current track info back to popup
-        debug('GET_CURRENT_TRACK message received, triggering track detection');
-        this.detectCurrentTrack();
-        this.sendCurrentTrackInfo(sendResponse);
-        break;
       default:
         // Handle other message types if needed
         break;
     }
     
     sendResponse();
-  }
-
-  /**
-   * Send current track info to popup
-   */
-  private sendCurrentTrackInfo(sendResponse: (response?: any) => void): void {
-    try {
-      if (!this.isExtensionContextValid()) {
-        sendResponse({ success: false, error: 'Extension context invalidated' });
-        return;
-      }
-
-      const track = this.extractTrackInfo();
-      
-      if (track) {
-        const convertedTrack = convertYouTubeTrack(track);
-        debug('Sending current track info to popup', {
-          track: {
-            artist: convertedTrack.artist,
-            title: convertedTrack.title,
-            album: convertedTrack.album,
-            duration: convertedTrack.duration,
-            isPlaying: track.isPlaying
-          }
-        });
-        
-        sendResponse({
-          success: true,
-          track: convertedTrack,
-          isPlaying: track.isPlaying,
-          currentTime: track.currentTime,
-          thumbnail: track.thumbnail
-        });
-      } else {
-        debug('No current track to send to popup');
-        sendResponse({
-          success: true,
-          track: null,
-          isPlaying: false
-        });
-      }
-    } catch (error) {
-      log('error', 'Failed to send current track info:', error);
-      sendResponse({ success: false, error: 'Failed to get current track' });
-    }
   }
 
   /**


### PR DESCRIPTION
The extension was previously fetching the current track information directly from the active tab's content script. This caused the popup to incorrectly display "Not on YouTube Music" if the active tab was not the YouTube Music tab.

This commit refactors the architecture to use the background service worker as a centralized store for the currently playing track information.

- The background script now caches the current track and responds to requests for it.
- The popup script now queries the background script, ensuring it always gets the correct track information regardless of the active tab.
- The content script has been simplified by removing the now-redundant message handler.
- Tab listeners have been added to the background script to clear the cached track information when the YouTube Music tab is closed or navigates to a different page.