### PR TITLE
Remove "identity" permission from manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,6 @@
   "permissions": [
     "storage",
     "activeTab",
-    "identity",
     "notifications",
     "tabs"
   ],


### PR DESCRIPTION
The "identity" permission is not used by the extension and has been removed from the manifest to request only necessary permissions, following Chrome extension best practices.