### PR TITLE
Persist scrobble queue updates during processing

### DIFF
--- a/src/api/scrobbler.ts
+++ b/src/api/scrobbler.ts
@@ -224,27 +224,36 @@ export class Scrobbler {
         try {
           await this.sendScrobble(item);
           log('info', `Successfully scrobbled: ${item.track.artist} - ${item.track.title}`);
+          await this.saveAfterDequeue();
         } catch (error) {
           log('error', `Failed to scrobble: ${item.track.artist} - ${item.track.title}`, error);
           
           // Retry logic
           if (item.retryCount < LASTFM_CONSTANTS.MAX_RETRIES) {
             item.retryCount++;
-            this.scrobbleQueue.unshift(item); // Put back at the front
+            await this.requeueAndSave(item);
             await sleep(LASTFM_CONSTANTS.RETRY_DELAY * item.retryCount);
           } else {
             log('error', `Max retries exceeded for: ${item.track.artist} - ${item.track.title}`);
+            await this.saveAfterDequeue();
           }
         }
 
         // Rate limiting
         await sleep(200); // 200ms between requests
       }
-
-      await this.saveScrobbleQueue();
     } finally {
       this.isProcessing = false;
     }
+  }
+
+  private async saveAfterDequeue(): Promise<void> {
+    await this.saveScrobbleQueue();
+  }
+
+  private async requeueAndSave(item: ScrobbleQueueItem): Promise<void> {
+    this.scrobbleQueue.unshift(item);
+    await this.saveScrobbleQueue();
   }
 
   /**


### PR DESCRIPTION
### Motivation

- Ensure the scrobble queue state is persisted during processing so items are not lost if the service worker stops or crashes.  
- Make retry behavior durable by persisting the queue when items are reinserted for retry.  
- Reduce duplication and clarify queue state changes by encapsulating save logic.  

### Description

- Updated `src/api/scrobbler.ts` to persist queue changes from `processQueue` after each dequeue or on retry by calling `saveScrobbleQueue`.  
- Added helper methods `saveAfterDequeue()` and `requeueAndSave(item)` to encapsulate ``remove + save`` and ``requeue + save`` semantics.  
- Replaced direct `this.scrobbleQueue.unshift(item)` in retry logic with `await this.requeueAndSave(item)`, and call `await this.saveAfterDequeue()` on successful scrobble or when max retries are exceeded.  
- Removed the single end-of-loop `await this.saveScrobbleQueue()` in favor of per-step persistence.  

### Testing

- No automated tests were run as part of this change.  
- Existing build and type-check pipelines were not executed by this change set.  
- Manual review of the modified `processQueue` logic was performed to verify save calls were added in the correct locations.  
- Recommend running `npm test`, `npm run type-check`, and extension runtime validation after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e75924c4c83339713cb88ad42f0f0)