### PR TITLE
Fix popup not updating when track starts playing

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -153,7 +153,7 @@ class PopupController {
   private setupMessageListeners(): void {
     chrome.runtime.onMessage.addListener((message: Message, _sender, _sendResponse) => {
       console.log('[Madrak] Popup received message:', message.type);
-      
+
       switch (message.type) {
         case 'AUTH_SUCCESS':
           this.handleAuthSuccess(message.data);
@@ -163,6 +163,24 @@ class PopupController {
           break;
         case MESSAGE_TYPES.SETTINGS_UPDATE:
           this.handleSettingsUpdate(message.data);
+          break;
+        case MESSAGE_TYPES.TRACK_DETECTED:
+          if (this.isAuthenticated && message.data) {
+            this.showCurrentTrack(message.data.track, {
+              isPlaying: message.data.youtubeTrack?.isPlaying,
+              currentTime: message.data.youtubeTrack?.currentTime,
+              thumbnail: message.data.youtubeTrack?.thumbnail,
+            });
+          }
+          break;
+        case 'TRACK_CHANGED':
+          if (this.isAuthenticated && message.data?.newTrack) {
+            this.showCurrentTrack(message.data.newTrack.track, {
+              isPlaying: message.data.newTrack.youtubeTrack?.isPlaying,
+              currentTime: message.data.newTrack.youtubeTrack?.currentTime,
+              thumbnail: message.data.newTrack.youtubeTrack?.thumbnail,
+            });
+          }
           break;
         default:
           console.log('[Madrak] Popup: Unknown message type:', message.type);


### PR DESCRIPTION
## Summary
- The popup's message listener only handled auth and settings messages, ignoring `TRACK_DETECTED` and `TRACK_CHANGED` from the content script
- If the popup was opened before a song started playing, it showed "Open YouTube Music" / "Ready to scrobble" and never updated
- Added handlers for both message types so the popup updates the track display immediately when playback is detected

## Test plan
- [ ] Open the popup before playing any song on YouTube Music — should show "Open YouTube Music"
- [ ] Start playing a song — popup should update within seconds to show the track title, artist, album art, and scrobble status
- [ ] Switch songs — popup should update to show the new track
- [ ] Pause/resume — popup should reflect the play state change

🤖 Generated with [Claude Code](https://claude.com/claude-code)